### PR TITLE
fix userproperties message type assumption

### DIFF
--- a/listener_test.go
+++ b/listener_test.go
@@ -106,7 +106,7 @@ func createNewListenerFromConnectionString() (*Listener, error) {
 }
 
 func createTestHandler() Handle {
-	return func(ctx context.Context, message string) error {
+	return func(ctx context.Context, message string, messageType string) error {
 		return nil
 	}
 }

--- a/suite_test.go
+++ b/suite_test.go
@@ -199,7 +199,7 @@ func (suite *serviceBusSuite) publishAndReceiveMessage(testConfig publishReceive
 }
 
 func checkResultHandler(publishedMsg string, ch chan<- bool) Handle {
-	return func(ctx context.Context, message string) error {
+	return func(ctx context.Context, message string, messageType string) error {
 		if publishedMsg != message {
 			ch <- false
 			return errors.New("published message and received message are different")


### PR DESCRIPTION
we were assuming that the "type" field of UserProperties was always there. however it is possible that it's not there if the publisher is not using this library. fixing the assumption and abandoning the message if the field is not there (abandoning instead of completing so that it will eventually end up on the deadletter queue).