### PR TITLE
make publisher reuse the topic as a sender

### DIFF
--- a/publisher.go
+++ b/publisher.go
@@ -15,7 +15,7 @@ import (
 // Publisher is a struct to contain service bus entities relevant to publishing to a topic
 type Publisher struct {
 	namespace              *servicebus.Namespace
-	topicSender            *servicebus.Sender
+	topic                  *servicebus.Topic
 	headers                map[string]string
 	topicManagementOptions []servicebus.TopicManagementOption
 }
@@ -150,16 +150,8 @@ func NewPublisher(topicName string, opts ...PublisherManagementOption) (*Publish
 	if err != nil {
 		return nil, fmt.Errorf("failed to create new topic %s: %w", topicEntity.Name, err)
 	}
-	defer func() {
-		_ = topic.Close(context.Background())
-	}()
 
-	topicSender, err := topic.NewSender(context.Background())
-	if err != nil {
-		return nil, fmt.Errorf("failed to create new topic sender for topic %s: %w", topicEntity.Name, err)
-	}
-	publisher.topicSender = topicSender
-
+	publisher.topic = topic
 	return publisher, nil
 }
 
@@ -189,9 +181,9 @@ func (p *Publisher) Publish(ctx context.Context, msg interface{}, opts ...Publis
 	}
 
 	// finally, send
-	err = p.topicSender.Send(ctx, sbMsg)
+	err = p.topic.Send(ctx, sbMsg)
 	if err != nil {
-		return fmt.Errorf("failed to send message to topic %s: %w", p.topicSender.Name, err)
+		return fmt.Errorf("failed to send message to topic %s: %w", p.topic.Name, err)
 	}
 	return nil
 }

--- a/scripts/test-setup.sh
+++ b/scripts/test-setup.sh
@@ -8,6 +8,15 @@ az group create \
 --location ${TEST_LOCATION} \
 -o none
 
+echo "create managed identity"
+MANAGED_IDENTITY_CLIENT_ID=$(az identity create \
+--name "${SERVICEBUS_NAMESPACE_NAME}_id" \
+-g ${TEST_RESOURCE_GROUP} \
+--query clientId \
+-o tsv)
+
+MANAGED_IDENTITY_RESOURCE_ID="/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${TEST_RESOURCE_GROUP}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${SERVICEBUS_NAMESPACE_NAME}_id"
+
 echo "creating ACR"
 az acr create \
 --name ${REGISTRY_NAME} \
@@ -37,16 +46,6 @@ SERVICEBUS_CONNECTION_STRING=$(az servicebus namespace authorization-rule keys l
 --name "RootManageSharedAccessKey" \
 --query primaryConnectionString \
 -o tsv)
-
-
-echo "create managed identity"
-MANAGED_IDENTITY_CLIENT_ID=$(az identity create \
---name "${SERVICEBUS_NAMESPACE_NAME}_id" \
--g ${TEST_RESOURCE_GROUP} \
---query clientId \
--o tsv)
-
-MANAGED_IDENTITY_RESOURCE_ID="/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourcegroups/${TEST_RESOURCE_GROUP}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${SERVICEBUS_NAMESPACE_NAME}_id"
 
 echo "assign servicebus role to identity"
 az role assignment create \

--- a/suite_test.go
+++ b/suite_test.go
@@ -49,7 +49,7 @@ type publishReceiveTest struct {
 	listener         *Listener
 	publisher        *Publisher
 	listenerOptions  []ListenerOption
-	publisherOptions []PublisherOption
+	publisherOptions []PublishOption
 	publishCount     *int
 	shouldSucceed    bool
 }
@@ -209,7 +209,7 @@ func (suite *serviceBusSuite) duplicateDetectionTest(publisher *Publisher, liste
 			listener:         listener,
 			publisher:        publisher,
 			listenerOptions:  []ListenerOption{SetSubscriptionName("subName4")},
-			publisherOptions: []PublisherOption{SetMessageID("hi")},
+			publisherOptions: []PublishOption{SetMessageID("hi")},
 			publishCount:     &publishCount,
 			shouldSucceed:    true,
 		},


### PR DESCRIPTION
we were closing the topic, and creating single sender instead, making possible to succeed creating a topic, but fail creating a sender.

the topic.Send wraps Sender.Send by ensuring that the connection is healthy.
We reuse the topic and benefit from the wrapper, while removing the extra connection closing and opening.